### PR TITLE
Add vulnerable IIS to Metasploitable3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,10 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "scripts/create_users.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
 
+  # Vulnerability - Unpatched IIS
+  config.vm.provision :shell, path: "resources/iis/setup_iis.bat"
+  config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
+
   # Vulnerability - Setup for Apache Struts
   config.vm.provision :shell, path: "scripts/chocolatey_installs/java.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614

--- a/resources/iis/setup_iis.bat
+++ b/resources/iis/setup_iis.bat
@@ -1,0 +1,2 @@
+start /w PKGMGR.EXE /iu:IIS-WebServerRole;IIS-WebServer;IIS-CommonHttpFeatures;
+timeout 10

--- a/scripts/configure_firewall.bat
+++ b/scripts/configure_firewall.bat
@@ -1,1 +1,2 @@
 netsh advfirewall firewall add rule name="Open Port 8080 for Apache Struts" dir=in action=allow protocol=TCP localport=8080
+netsh advfirewall firewall add rule name="Open Port 80 for IIS" dir=in action=allow protocol=TCP localport=80


### PR DESCRIPTION
This PR adds an unpatched IIS web server for Metasploitable3.

Verification:
- [ ] Install packer with `brew install packer`
- [ ] Install packer with `brew install packer`
- [ ] Install Vagrant with `brew install vagrant`
- [ ] Install Virtualbox
- [ ] Clone this repo and check out this branch
- [ ] Build the base VM using `packer build windows_2008_r2.json`
- [ ] Add the resulting .box file to vagrant using `vagrant box add windows_2008_r2_virtualbox.box --name metasploitable3`
- [ ] Bring up the vagrant environment using the command `vagrant up`
- [ ] When the system is up, do `netstat -an | find "80"`. Port 80 should be running.

If you run auxiliary/dos/http/ms15_034_ulonglongadd against the IIS server, it should dos the box too (blue screen)
