### PR TITLE
Update firewall rules for Remote Desktop

### DIFF
--- a/scripts/configure_firewall.bat
+++ b/scripts/configure_firewall.bat
@@ -1,2 +1,3 @@
 netsh advfirewall firewall add rule name="Open Port 8080 for Apache Struts" dir=in action=allow protocol=TCP localport=8080
 netsh advfirewall firewall add rule name="Open Port 80 for IIS" dir=in action=allow protocol=TCP localport=80
+netsh advfirewall firewall add rule name="Open Port 3389 for Remote Desktop" dir=in action=allow protocol=TCP localport=3389


### PR DESCRIPTION
This creates a new firewall rule for Remote Desktop.

Verification:
- [ ] Install packer with `brew install packer`
- [ ] Install packer with `brew install packer`
- [ ] Install Vagrant with `brew install vagrant`
- [ ] Install Virtualbox
- [ ] Clone this repo and check out this branch
- [ ] Build the base VM using `packer build windows_2008_r2.json`
- [ ] Add the resulting .box file to vagrant using `vagrant box add windows_2008_r2_virtualbox.box --name metasploitable3`
- [ ] Bring up the vagrant environment using the command `vagrant up`
- [ ] Connect to the machine with a Remote Desktop client, such as: https://download.microsoft.com/download/C/F/0/CF0AE39A-3307-4D39-9D50-58E699C91B2F/RDC_2.1.1_ALL.dmg (for OS X). You should be able to connect to it.
