### PR TITLE
Add Jenkins to Metasploitable3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision :reload # Hack to reset environment variables
   config.vm.provision :shell, path: "resources/apache_struts/setup_apache_struts.bat"
 
-  # Vulnerability - Jenkins
+  # Vulnerability - Jenkins (1.8)
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
   config.vm.provision :shell, path: "resources/jenkins/setup_jenkins.bat"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "scripts/create_users.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
 
+
   # Vulnerability - Unpatched IIS
   config.vm.provision :shell, path: "resources/iis/setup_iis.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
@@ -43,6 +44,10 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
   config.vm.provision :reload # Hack to reset environment variables
   config.vm.provision :shell, path: "resources/apache_struts/setup_apache_struts.bat"
+
+  # Vulnerability - Jenkins
+  config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
+  config.vm.provision :shell, path: "resources/jenkins/setup_jenkins.bat"
 
   # Configure Firewall to open up vulnerable services
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614

--- a/resources/jenkins/setup_jenkins.bat
+++ b/resources/jenkins/setup_jenkins.bat
@@ -1,5 +1,5 @@
 mkdir "%ProgramFiles%\jenkins"
 copy C:\vagrant\resources\jenkins\jenkins.war "%ProgramFiles%\jenkins"
 copy C:\vagrant\resources\jenkins\start_jenkins.bat "%ProgramFiles%\jenkins"
-schtasks /create /tn "Jenkins" /tr "\"%ProgramFiles%\jenkins\start_jenkins.bat\"" /sc onstart
+schtasks /create /tn "Jenkins" /tr "\"%ProgramFiles%\jenkins\start_jenkins.bat\"" /sc onstart /np
 schtasks /run /tn "Jenkins"

--- a/resources/jenkins/setup_jenkins.bat
+++ b/resources/jenkins/setup_jenkins.bat
@@ -1,0 +1,3 @@
+mkdir "%ProgramFiles%\jenkins"
+copy C:\vagrant\resources\jenkins\jenkins.war "%ProgramFiles%\jenkins"
+java -jar "%ProgramFiles%\jenkins\jenkins.war" --httpPort=8181

--- a/resources/jenkins/setup_jenkins.bat
+++ b/resources/jenkins/setup_jenkins.bat
@@ -1,3 +1,5 @@
 mkdir "%ProgramFiles%\jenkins"
 copy C:\vagrant\resources\jenkins\jenkins.war "%ProgramFiles%\jenkins"
-java -jar "%ProgramFiles%\jenkins\jenkins.war" --httpPort=8181
+copy C:\vagrant\resources\jenkins\start_jenkins.bat "%ProgramFiles%\jenkins"
+schtasks /create /tn "Jenkins" /tr "\"%ProgramFiles%\jenkins\start_jenkins.bat\"" /sc onstart
+schtasks /run /tn "Jenkins"

--- a/resources/jenkins/start_jenkins.bat
+++ b/resources/jenkins/start_jenkins.bat
@@ -1,0 +1,1 @@
+java -jar "%ProgramFiles%\jenkins\jenkins.war" --httpPort=8181

--- a/scripts/configure_firewall.bat
+++ b/scripts/configure_firewall.bat
@@ -1,2 +1,3 @@
+netsh advfirewall firewall add rule name="Open Port 8181 for Jenkins" dir=in action=allow protocol=TCP localport=8181
 netsh advfirewall firewall add rule name="Open Port 8080 for Apache Struts" dir=in action=allow protocol=TCP localport=8080
 netsh advfirewall firewall add rule name="Open Port 80 for IIS" dir=in action=allow protocol=TCP localport=80


### PR DESCRIPTION
This adds a vulnerable Jenkins service to Metasploitable3

Verification:
- [ ] Install packer with `brew install packer`
- [ ] Install packer with `brew install packer`
- [ ] Install Vagrant with `brew install vagrant`
- [ ] Install Virtualbox
- [ ] Clone this repo and check out this branch
- [ ] Build the base VM using `packer build windows_2008_r2.json`
- [ ] Add the resulting .box file to vagrant using `vagrant box add windows_2008_r2_virtualbox.box --name metasploitable3`
- [ ] Bring up the vagrant environment using the command `vagrant up`
- [ ] Make sure port 8181 is open, and you should be able to see it with a browser
